### PR TITLE
Size board cells depending on board and viewport size

### DIFF
--- a/diamonds-viewer/src/components/Cell.js
+++ b/diamonds-viewer/src/components/Cell.js
@@ -46,11 +46,20 @@ const Cell = (props) => {
     : c.base ? <p className={styles.cellSign}>{c.base}</p>
     : ''
 
+    if (props.windowSize.width > props.windowSize.height) {
+        var size = `calc(50vw / ${props.boardWidth})`;
+    } else {
+        var size = `calc(100vw / ${props.boardWidth} - 5px)`;
+    }
+     var cellStyle = {
+        width: size,
+        height: size
+    };
+
     return (
-        <div className={`${styles.cell} ${props.windowSize.width/props.windowSize.height > 2 ? styles.cellHeight: null}`} >
+        <div style={cellStyle} className={`${styles.cell} ${props.windowSize.width/props.windowSize.height > 2 ? styles.cellHeight: null}`} >
           {name}
           {image}
-          
         </div>
     )
 }


### PR DESCRIPTION
The size of the cells now adapt depending on the board and viewport size. It should now work even if using non-square boards and/or non-10x10 boards.