### PR TITLE
Updated POST /Boards/{id}/move to also return game state on failed moves

### DIFF
--- a/diamonds-api/Diamonds.Rest/Controllers/BoardsController.cs
+++ b/diamonds-api/Diamonds.Rest/Controllers/BoardsController.cs
@@ -64,19 +64,29 @@ namespace Diamonds.Rest.Controllers
         [Route("{id}")]
         public IActionResult GetBoard(string id)
         {
-
-            var board = _storage.GetBoard(id);
-
+            var board = GetAndGenerateBoard(id);
             if (board == null)
             {
                 return NotFound();
             }
-            if(_diamondGeneratorService.NeedToGenerateDiamonds(board)){
+
+            return Ok(board);
+        }
+
+        private Board GetAndGenerateBoard(string id)
+        {
+            var board = _storage.GetBoard(id);
+            if(board == null)
+            {
+                return null;
+            }
+
+            if(_diamondGeneratorService.NeedToGenerateDiamonds(board))
+            {
                 regenerateBoardObjects(board);
                 _storage.UpdateBoard(board);
             }
-
-            return Ok(board);
+            return board;
         }
 
         /// <summary>
@@ -232,13 +242,12 @@ namespace Diamonds.Rest.Controllers
             }
 
             var moveResult = _moveService.Move(id, bot.Name, input.direction);
-
             if (moveResult != MoveResultCode.Ok)
             {
-                return StatusCode(409);
+                return StatusCode(409, GetAndGenerateBoard(id));
             }
 
-            return GetBoard(id);
+            return Ok(GetAndGenerateBoard(id));
         }
     }
 }


### PR DESCRIPTION
See issue #80.
Returns game state in the body of POST  "/Boards/{id}/move" even if the move is blocked for some reason.