### PR TITLE
Fix multiple diamonds spawning in one cell

### DIFF
--- a/diamonds-api/Diamonds.GameEngine/DiamondGeneratorService.cs
+++ b/diamonds-api/Diamonds.GameEngine/DiamondGeneratorService.cs
@@ -33,7 +33,12 @@ namespace Diamonds.GameEngine
             while (diamondPositions.Count < maxNumberOfDiamonds)
             {
                 var diamondPositionToAdd = board.GetRandomEmptyPosition();
-                diamondPositions.Add(new DiamondPosition(diamondPositionToAdd));
+                var positionHasDiamond = diamondPositions.Contains(diamondPositionToAdd);
+
+                if (positionHasDiamond == false) 
+                {
+                    diamondPositions.Add(new DiamondPosition(diamondPositionToAdd));
+                }
             }
 
             // Replace some diamonds with red ones


### PR DESCRIPTION
**Please look into #82 before merging this.**

Fixes #79 

``board.GetRandomEmptyPosition()`` looks at the ``board.Diamonds`` list to decide whether a cell is already occupied by a diamond, but ``board.Diamonds`` is never updated before the diamond generation has completed. Because of that, it doesn't know of diamonds that were added during the generation.

This quick change makes it so it simply queries the list of generated diamonds to see if a position is taken, **in addition to** ``board.GetRandomEmptyPosition()``'s ordinary ``board.Diamonds`` check.